### PR TITLE
Increase Code128 extended pattern max length to 48 characters

### DIFF
--- a/config/types/Code128.json
+++ b/config/types/Code128.json
@@ -20,7 +20,7 @@
 	"example": "Try Me!",
 	"pattern": {
 		"auto": "^[ !#$()*.\\/0-9=?A-Z_a-z~]{1,16}$",
-		"extended": "^[ !\\\"#$%&\\'()*+,\\-.\\/0-9:;<=>?@A-Z\\[\\]^_`a-z{|}~]{1,36}$"
+		"extended": "^[ !\\\"#$%&\\'()*+,\\-.\\/0-9:;<=>?@A-Z\\[\\]^_`a-z{|}~]{1,48}$"
 	},
 	"description": {
 		"en": "A medium densisty alphanumeric barcode with a larger character set."


### PR DESCRIPTION
The specification for Code 128 (ISO/IEC 15417) leaves the maximum length undefined and states that this is something that should be defined by any derivative application[*] standard, therfore ultimately I understand you can set it to 36 if you would like, however for example the GS1 General Specification define that GS1-128 (the formal application of Code 128 to the supply chain industry) has a limits of 48 characters per symbol which our use case follows and 36 breaks our use. 

If it doesnt cause issue could we extend to match the general standard?

```
5.4.1 GS1-128 Bar Code Symbol size characteristics:

The characteristics of the GS1-128 Symbology are:

GS1-128 Bar Code Symbol size characteristics:

The maximum number of data characters in a single symbol is 48.
```

If not i will likely run the server on a fork and update for our use case but i opened a seperate ticket with some build issues when i was testing